### PR TITLE
fix: updates on existing toasts and displaying of icons.

### DIFF
--- a/dev/components/Types/index.tsx
+++ b/dev/components/Types/index.tsx
@@ -72,8 +72,11 @@ toast.promise(promise, {
     action: () =>
       toast.promise<{ name: string }>(
         () =>
-          new Promise((resolve) => {
+          new Promise((resolve, reject) => {
             setTimeout(() => {
+              const random50Percent = Math.floor(Math.random() * 2)
+              if (random50Percent > 0)
+                reject(new Error('Something\'s not right!'))
               resolve({ name: 'Solid Sonner' })
             }, 1500)
           }),
@@ -85,6 +88,31 @@ toast.promise(promise, {
           error: 'Error',
         },
       ),
+  },
+  {
+    name: 'Loading',
+    snippet: `const promise = () => new Promise((resolve) => setTimeout(resolve, 800));
+
+toast.loading('Uploading...', { id: 'form' });
+await promise();
+toast.loading('Saving...', { id: 'form'});
+await promise();
+toast.success('Success!', { id: 'form' });
+`,
+    action: async () => {
+      const idAlphabet = 'abcdefghijklmnopqrstuvwxyz1234567890'
+      const getRandomIndex = () => Math.floor(Math.random() * idAlphabet.length)
+      const toastId = idAlphabet[getRandomIndex()]! + idAlphabet[getRandomIndex()]! + idAlphabet[getRandomIndex()]!
+
+      const promise = () => new Promise((resolve) => {
+        setTimeout(resolve, 1000)
+      })
+      toast.loading('Uploading...', { id: toastId })
+      await promise()
+      toast.loading('Saving...', { id: toastId })
+      await promise()
+      toast.success('Success!', { id: toastId })
+    },
   },
   {
     name: 'Custom',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -341,8 +341,7 @@ const Toast: Component<ToastProps> = (props) => {
             <Show when={toastType() || props.toast.icon || props.toast.promise}>
               <div data-icon="">
                 {props.toast.promise || (props.toast.type === 'loading' && !props.toast.icon) ? props.toast.icon || getLoadingIcon() : null}
-                {/* @ts-expect-error Some icons don't display when toast type updates existing toasts. TODO: Can be improved to be written in the "solid-way". This removes the bug. */}
-                {props.toast.type !== 'loading' ? props.toast.icon || props.icons?.[toastType() as unknown as keyof typeof props.icons] || getAsset(toastType()!)! : null}
+                {props.toast.type !== 'loading' ? props.toast.icon || props.icons?.[toastType() as unknown as keyof typeof props.icons] || getAsset(toastType()!)!() : null}
               </div>
             </Show>
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@
  * https://github.com/emilkowalski/sonner/blob/main/src/index.tsx
  */
 import './styles.css'
-import type { Component, ValidComponent } from 'solid-js'
+import type { Component } from 'solid-js'
 import { For, Show, createEffect, createSignal, mergeProps, on, onCleanup, onMount } from 'solid-js'
 import { createStore, produce, reconcile } from 'solid-js/store'
 import { Loader, getAsset } from './assets'


### PR DESCRIPTION
## Summary
- Fixes https://github.com/wobsoriano/solid-sonner/issues/15
- Fixes https://github.com/wobsoriano/solid-sonner/issues/14
- Fixed it by making it more "Solid-like". Solid prefers "fine-grained reactivity" that's why it was buggy because it can't seem to maintain referential stability when the array of objects get shifted around or updated in place.
- In Solid, referential volatility communicates **change**. Referential stability communicates nothing changed. Spreading = referential volatility.
- Basically in Solid, always avoid **spreading** when setting to state. Try to use **stores** for those usecases.
- Topics you can look into to learn about how this fix was done:
   - [GitHub Discussion - Why there's no key for referential stability](https://github.com/solidjs/solid/discussions/366)
   - [createStore](docs.solidjs.com/reference/store-utilities/create-store#createstore)
   - [produce](docs.solidjs.com/reference/store-utilities/produce#produce)
   - [reconcile](https://docs.solidjs.com/reference/store-utilities/reconcile#reconcile)

Before Fix:

https://github.com/wobsoriano/solid-sonner/assets/38070918/a24670ce-3603-4ab0-aeba-1f326cb1d074

After Fix:

https://github.com/wobsoriano/solid-sonner/assets/38070918/89c1a0b1-c666-4007-9852-9065682bd820

