### PR TITLE
TypeScript 6 and Vite+ commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ tsup.config.bundled_*.{m,c,}s
 /playwright/.cache/
 .agents/
 skills-lock.json
+
+# vite-plus generated hook dispatcher
+.vite-hooks/_

--- a/.vite-hooks/pre-commit
+++ b/.vite-hooks/pre-commit
@@ -1,0 +1,1 @@
+vp staged

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "scripts": {
     "dev": "vite serve dev",
+    "prepare": "vp config",
     "build": "vp pack",
     "dev:build": "vite build dev",
     "test": "playwright test",
@@ -55,7 +56,7 @@
     "copy-to-clipboard": "^4.0.2",
     "highlight.js": "^11.12.0",
     "solid-js": "^1.9.14",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "unplugin-solid": "^2.0.0",
     "vite": "^8.2.1",
     "vite-plugin-solid": "^2.11.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^1.9.14
         version: 1.9.14
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       unplugin-solid:
         specifier: ^2.0.0
         version: 2.0.0(esbuild@0.27.3)(rolldown@1.2.4)(rollup@4.59.0)(solid-js@1.9.14)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))
@@ -40,7 +40,7 @@ importers:
         version: 2.11.14(solid-js@1.9.14)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))
       vite-plus:
         specifier: ^0.2.9
-        version: 0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(jsdom@24.1.3)(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))(yaml@2.9.0)
+        version: 0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(jsdom@24.1.3)(typescript@6.0.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))(yaml@2.9.0)
 
 packages:
 
@@ -2138,8 +2138,8 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3320,7 +3320,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
-  '@voidzero-dev/vite-plus-core@0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.9.0)':
+  '@voidzero-dev/vite-plus-core@0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(typescript@6.0.3)(yaml@2.9.0)':
     dependencies:
       '@oxc-project/runtime': 0.143.0
       '@oxc-project/types': 0.143.0
@@ -3340,7 +3340,7 @@ snapshots:
       '@voidzero-dev/vite-plus-win32-x64-msvc': 0.2.9
       esbuild: 0.27.3
       fsevents: 2.3.3
-      typescript: 5.9.3
+      typescript: 6.0.3
       yaml: 2.9.0
 
   '@voidzero-dev/vite-plus-darwin-arm64@0.2.9':
@@ -3987,7 +3987,7 @@ snapshots:
 
   outdent@0.5.0: {}
 
-  oxfmt@0.62.0(vite-plus@0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(jsdom@24.1.3)(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))(yaml@2.9.0)):
+  oxfmt@0.62.0(vite-plus@0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(jsdom@24.1.3)(typescript@6.0.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -4010,7 +4010,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.62.0
       '@oxfmt/binding-win32-ia32-msvc': 0.62.0
       '@oxfmt/binding-win32-x64-msvc': 0.62.0
-      vite-plus: 0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(jsdom@24.1.3)(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))(yaml@2.9.0)
+      vite-plus: 0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(jsdom@24.1.3)(typescript@6.0.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))(yaml@2.9.0)
 
   oxlint-tsgolint@7.0.2001:
     optionalDependencies:
@@ -4021,7 +4021,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 7.0.2001
       '@oxlint-tsgolint/win32-x64': 7.0.2001
 
-  oxlint@1.77.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(jsdom@24.1.3)(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))(yaml@2.9.0)):
+  oxlint@1.77.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(jsdom@24.1.3)(typescript@6.0.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))(yaml@2.9.0)):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.77.0
       '@oxlint/binding-android-arm64': 1.77.0
@@ -4043,7 +4043,7 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.77.0
       '@oxlint/binding-win32-x64-msvc': 1.77.0
       oxlint-tsgolint: 7.0.2001
-      vite-plus: 0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(jsdom@24.1.3)(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))(yaml@2.9.0)
+      vite-plus: 0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(jsdom@24.1.3)(typescript@6.0.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))(yaml@2.9.0)
 
   p-filter@2.1.0:
     dependencies:
@@ -4327,7 +4327,7 @@ snapshots:
       punycode: 2.3.1
     optional: true
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   undici-types@7.18.2: {}
 
@@ -4394,7 +4394,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plus@0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(jsdom@24.1.3)(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))(yaml@2.9.0):
+  vite-plus@0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(jsdom@24.1.3)(typescript@6.0.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@oxc-project/types': 0.143.0
       '@oxlint/plugins': 1.73.0
@@ -4407,9 +4407,9 @@ snapshots:
       '@vitest/snapshot': 4.1.10
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
-      '@voidzero-dev/vite-plus-core': 0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.9.0)
-      oxfmt: 0.62.0(vite-plus@0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(jsdom@24.1.3)(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))(yaml@2.9.0))
-      oxlint: 1.77.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(jsdom@24.1.3)(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))(yaml@2.9.0))
+      '@voidzero-dev/vite-plus-core': 0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(typescript@6.0.3)(yaml@2.9.0)
+      oxfmt: 0.62.0(vite-plus@0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(jsdom@24.1.3)(typescript@6.0.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint: 1.77.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@24.13.3)(esbuild@0.27.3)(jsdom@24.1.3)(typescript@6.0.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))(yaml@2.9.0))
       oxlint-tsgolint: 7.0.2001
       vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-preview@4.1.10)(jsdom@24.1.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.27.3)(yaml@2.9.0))
     optionalDependencies:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,10 @@ export default defineConfig({
       outExtensions: () => ({ js: '.jsx' }),
     },
   ],
+  staged: {
+    '*.{ts,tsx,js,jsx}': 'vp check --fix',
+    '*.{css,json,md,yml,yaml}': 'vp fmt',
+  },
   fmt: {
     singleQuote: true,
     ignorePatterns: ['CHANGELOG.md'],


### PR DESCRIPTION
### TypeScript 6

`typescript` 5.9.3 -> 6.0.3.

Build output is **byte-identical** to what 0.3.2 published under 5.9 — `dist/index.js`, `dist/index.jsx` and `dist/index.d.ts` all diff clean against the published tarball. `tsc --noEmit` passes, and the consumer smoke app already typechecks against the package under TS 6.

Staying on 6 rather than 7: `vp pack` warns that TypeScript 7 has no stable API yet, and tsgolint (the TS7-based type-aware linter) disagrees with it on config we rely on.

### Commit hooks

Adds the Vite+ git hook dispatcher, replacing nothing — the repo had no hooks before.

- `.vite-hooks/pre-commit` runs `vp staged` (committed to the repo)
- `staged` config in `vite.config.ts` applies `vp check --fix` to staged sources and `vp fmt` to css/json/md/yml
- `prepare` runs `vp config`, so the dispatcher installs on `pnpm install` for every contributor
- the generated `.vite-hooks/_` dispatcher is gitignored

Behaviour verified by committing against it rather than assuming:

| Case | Result |
|---|---|
| Badly formatted staged file | Fixed and re-staged; the commit contains the formatted version |
| File that fails to parse | Commit blocked, `pre-commit script failed (code 1)` |
| Lint **warning** (e.g. `no-debugger`) | Does not block — matches `vp check` in CI |

Type errors don't block, since `vp check` doesn't run `tsc`. Adding `vp run typecheck` to the hook would cover that at the cost of a slower commit — happy to add if you want it.